### PR TITLE
Adding support to import submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Checks if there are new merge requests or merge requests with new commits.
 
 `git clone`s the source branch of the respective merge request.
 
+### Parameters
+
+* `submodules`: Optional. If `none`, submodules will not be fetched. If not specified, or if `all` is explicitly specified, all submodules are fetched.
+
 ### `out`: Update a merge request's merge status
 
 Updates the merge request's `merge_status` which displays nicely in the GitLab UI and allows to only merge changes if they pass the test.

--- a/in/models.go
+++ b/in/models.go
@@ -7,9 +7,14 @@ import (
 type Request struct {
 	Source  resource.Source  `json:"source"`
 	Version resource.Version `json:"version"`
+	Params Params            `json:"params"`
 }
 
 type Response struct {
 	Version  resource.Version  `json:"version"`
 	Metadata resource.Metadata `json:"metadata"`
+}
+
+type Params struct {
+	Submodules string   `json:"submodules"`
 }

--- a/models.go
+++ b/models.go
@@ -37,6 +37,13 @@ func (source *Source) GetBaseURL() string {
 	return host + "/api/v4"
 }
 
+// GetGitlabHostName extracts host from URI (repository URL).
+func (source *Source) GetGitlabHost() string {
+	r, _ := regexp.Compile("gitlab[^/]+")
+	host := r.FindString(source.URI)
+	return host
+}
+
 // GetProjectPath extracts project path from URI (repository URL).
 func (source *Source) GetProjectPath() string {
 	r, _ := regexp.Compile("(https?|ssh)://([^/]*)/(.*)\\.git$")


### PR DESCRIPTION
By default, gitlab MR resource would import submodules listed in .submodules file of the project.
